### PR TITLE
Update how to setup time interval.

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -70,7 +70,7 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(
-      :subject, :place, :description, :start_time, :finish_time
+      :subject, :place, :description, :start_time, :planned_time
     )
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,9 +9,27 @@ class Event < ActiveRecord::Base
 
   validates :subject, presence: true
   validates :place, presence: true
+  validates :start_time, presence: true
+  validates :finish_time, presence: true
   validates :user_id, presence: true
 
   scope :with_users, -> { includes(:user, :members) }
+
+  before_validation :set_finish_time
+
+  def planned_time
+    if finish_time.nil? && start_time.nil?
+      1
+    elsif finish_time.present? && start_time.present?
+      ((finish_time - start_time) / 1.hour).to_i
+    else
+      @planned_time
+    end
+  end
+
+  def planned_time=(data)
+    @planned_time = data.to_i
+  end
 
   def editable?(user)
     user.id == user_id
@@ -86,5 +104,11 @@ class Event < ActiveRecord::Base
 
   def to_hex_with
     user&.id || 0
+  end
+
+  def set_finish_time
+    if start_time.present? && planned_time.present?
+      self.finish_time = start_time + planned_time.hour
+    end
   end
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -39,16 +39,8 @@
   <div class="row">
     <div class="col-xs-11">
       <div class="field form-group">
-        <label>Select the date:</label>
+        <%= f.label "시작 예정 시각" %>:
         <div class="quick-datetime-select" data-start-datetime="#start-time" data-end-datetime="#end-time"></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-xs-11">
-      <div class="field form-group">
-        <%= f.label :start_time %>:
         <div>
           <span id="start-time"><%= f.datetime_select :start_time, minute_step: 10 %></span>
         </div>
@@ -59,9 +51,11 @@
   <div class="row">
     <div class="col-xs-11">
       <div class="field form-group">
-        <%= f.label :finish_time %>:
-        <div>
-          <span id="end-time"><%= f.datetime_select :finish_time, minute_step: 10 %></span>
+        <div class="col-sm-3">
+          <%= f.label "예상 소요 시간" %>:
+        </div>
+        <div class="col-sm-4">
+          <span id="until-hour"><%= f.phone_field :planned_time, class: "form-control" %></span>
         </div>
       </div>
     </div>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe EventsController, type: :controller do
       place: "Place",
       description: "MyText",
       start_time: Time.zone.now,
-      finish_time: Time.zone.now + 1.hour
+      planned_time: "5"
     }
   end
 


### PR DESCRIPTION
원래 시간 지정을 시작, 종료 시각으로 했었으나, #108 과 같은 사용자 실수가 존재할 수 있다는 문제를 확인하고, 이러한 문제를 해소할 수 있도록 시작시간 + 이벤트 예상 소요 시간으로 UI 및 로직을 변경
