### PR TITLE
Remove 'Join' button from organizer view

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,8 +3,7 @@
 class EventsController < ApplicationController
   before_action :permission_check, only: [:edit, :update, :destroy, :copy]
 
-  def index
-  end
+  def index; end
 
   def show
     event
@@ -79,7 +78,7 @@ class EventsController < ApplicationController
   end
 
   def permission_check
-    raise User::NoPermission unless event.editable? current_user
+    raise User::NoPermission unless event.organizer? current_user
   end
 
   rescue_from ActiveRecord::RecordNotFound do

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -36,7 +36,7 @@ class Event < ApplicationRecord
     event
   end
 
-  def editable?(user)
+  def organizer?(user)
     user.id == user_id
   end
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -3,15 +3,15 @@
 
   <div class="row">
     <div class="col-xs-12">
-      <% if @event.in_time? %>
-        <% if @event.joined? @user %>
+      <% if !@event.organizer?(@user) && @event.in_time? %>
+        <% if @event.joined?(@user) %>
             <%= link_to "I cannot go T-T", unjoin_event_path(@event), method: :post, class: "btn btn-warning" %>
         <% else %>
             <%= link_to "Join", join_event_path(@event), method: :post, class: "btn btn-danger" %>
         <% end %>
       <% end %>
 
-      <% if @event.editable? @user %>
+      <% if @event.organizer?(@user) %>
         <%= link_to "Destroy", @event, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
       <% end %>
       <%= link_to "Back", events_path, class: "btn btn-success" %>

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe Event, type: :model do
     end
   end
 
-  describe "#editable?" do
+  describe "#organizer?" do
     it "expect return true" do
-      expect(@event.editable?(@user)).to be(true)
+      expect(@event.organizer?(@user)).to be(true)
     end
 
     it "expect return false" do
       user = create(:user)
-      expect(@event.editable?(user)).to be(false)
+      expect(@event.organizer?(user)).to be(false)
     end
   end
 


### PR DESCRIPTION
Related to #289 

Changed:

- `User#editable?` renamed to `User#organizer?`
- Show 'Join'/'Not Join' except organizer